### PR TITLE
Feat : HTTPException 발생 시, Response Header에 Access-Control-Allow-Origin 추가

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,16 +1,18 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from config import Settings
-from routes.authentication_route import router as auth_router
 from routes.admin.admin_books_route import router as admin_books_router
+from routes.admin.notice_route import router as admin_notice_router
+from routes.authentication_route import router as auth_router
 from routes.book_review_route import router as review_router
 from routes.bookrequest_route import router as bookrequest_router
 from routes.books_route import router as books_router
 from routes.loan_route import router as loan_router
-from routes.user_route import router as user_router
-from routes.admin.notice_route import router as admin_notice_router
 from routes.notice_route import router as notice_router
+from routes.user_route import router as user_router
 
 settings = Settings()
 
@@ -34,7 +36,7 @@ origins = [
     "http://localhost:10242",
     "http://localhost:5173",
     "http://localhost:3000",
-    "http://localhost:8000"
+    "https://localhost:8000"
 ]
 
 app.add_middleware(
@@ -42,7 +44,8 @@ app.add_middleware(
     allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
-    allow_headers=["*"]
+    allow_headers=["*"],
+    expose_headers=["Access-Control-Allow-Origin"]
 )
 
 app.include_router(auth_router)
@@ -55,6 +58,30 @@ app.include_router(bookrequest_router)
 app.include_router(admin_notice_router)
 app.include_router(notice_router)
 
+
+@app.exception_handler(StarletteHTTPException)
+async def http_exception_handler(request:Request, exc:StarletteHTTPException):
+
+    error_response = JSONResponse(content={"detail":exc.detail}, status_code=exc.status_code)
+
+    origin = request.headers.get("Origin")
+    if origin:
+        cors = CORSMiddleware(
+            app,
+            allow_origins=origins,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"]
+        )
+        error_response.headers.update(cors.simple_headers)
+
+        if cors.is_allowed_origin(origin=origin):
+            error_response.headers["Access-Control-Allow-Origin"] = origin
+
+        elif "cookie" in request.headers:
+            error_response.headers["Access-Control-Allow-Origin"] = origin
+
+    return error_response
 
 @app.get("/")
 async def root():


### PR DESCRIPTION
문제 : 
 Exception이 발생할 때 response header에 Access-Control-Allow-Origin 값이 없어 CORS 에러가 발생

**API에서 HTTPException 발생 시, 동작하는 exception handler 추가**
- Exception이 발생해도 에러에 대한 정보(detail, status_code)를 JsonResponse로 반환
- Request origin이 허용된 값이거나, Request에 cookie가 있을 때, Response Header에 Access-Control-Allow-Origin 값 추가


참고
[https://github.com/fastapi/fastapi/discussions/7847](url)