### PR TITLE
feat: 관리자 회원 탈퇴 기능

### DIFF
--- a/src/domain/schemas/user_schemas.py
+++ b/src/domain/schemas/user_schemas.py
@@ -25,3 +25,5 @@ class DomainResPutUser(BaseModel):
     github: str | None = Field(None, title="github", description="깃허브 주소", example="https://github.com/kucc")
     instagram: str | None = Field(None, title="instagram", description="인스타그램 주소", example="https://www.instagram.com/")
 
+class DomainReqAdminDelUser(BaseModel):
+    user_id: int = Field(title="user_id", description="유저 고유 ID", example=1111, gt=0)

--- a/src/domain/services/admin/user_service.py
+++ b/src/domain/services/admin/user_service.py
@@ -1,0 +1,10 @@
+from sqlalchemy.orm import Session
+
+from domain.schemas.user_schemas import DomainReqAdminDelUser
+from repositories.models import User
+from utils.crud_utils import delete_item
+
+
+async def service_admin_delete_user(request: DomainReqAdminDelUser, db: Session):
+    delete_item(User, request.user_id, db)
+    return

--- a/src/domain/services/admin/user_service.py
+++ b/src/domain/services/admin/user_service.py
@@ -1,5 +1,6 @@
 from fastapi import HTTPException, status
 from sqlalchemy import select, text
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session, selectinload
 
 from domain.schemas.user_schemas import DomainAdminGetUserItem, DomainReqAdminDelUser
@@ -109,5 +110,50 @@ async def service_admin_read_users(db: Session) -> list[DomainAdminGetUserItem]:
 
 
 async def service_admin_delete_user(request: DomainReqAdminDelUser, db: Session):
-    delete_item(User, request.user_id, db)
+    # 유저를 검색해서 관리자가 아니라면 바로 삭제. 관리자라면 관리자 테이블에서 이미 삭제되었는지 확인 후 삭제
+    stmt = (
+        select(User)
+        .options(
+            selectinload(User.admin)
+        )
+        .where(
+            User.id == request.user_id,
+            User.is_deleted == False
+        )
+    )
+
+    try:
+        user = db.execute(stmt).scalar_one()
+
+        if user.admin:
+            if not user.admin[0].is_deleted:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Cannot delete an active admin user"
+                )
+    except NoResultFound as e:
+        raise HTTPException(
+             status_code=status.HTTP_404_NOT_FOUND,
+             detail="User not found"
+        ) from e
+    except AttributeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected attribute error occurred: {str(e)}",
+        ) from e
+    except HTTPException as e:
+            raise e
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error occurred during user retrieval: {str(e)}",
+        ) from e
+    try:
+        delete_item(User, request.user_id, db)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error occurred during user deletion: {str(e)}",
+        ) from e
+
     return

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from config import Settings
 from routes.admin.admin_books_route import router as admin_books_router
 from routes.admin.notice_route import router as admin_notice_router
+from routes.admin.user_route import router as admin_user_router
 from routes.authentication_route import router as auth_router
 from routes.book_review_route import router as review_router
 from routes.bookrequest_route import router as bookrequest_router
@@ -57,6 +58,7 @@ app.include_router(review_router)
 app.include_router(bookrequest_router)
 app.include_router(admin_notice_router)
 app.include_router(notice_router)
+app.include_router(admin_user_router)
 
 
 @app.exception_handler(StarletteHTTPException)

--- a/src/routes/admin/user_route.py
+++ b/src/routes/admin/user_route.py
@@ -1,0 +1,31 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, status
+from sqlalchemy.orm import Session
+
+from dependencies import get_current_admin, get_db
+from domain.schemas.user_schemas import DomainReqAdminDelUser
+from domain.services.admin.user_service import service_admin_delete_user
+
+router = APIRouter(
+    prefix="/admin/users",
+    tags=["admin/users"],
+    dependencies=[Depends(get_current_admin)]
+)
+
+
+@router.delete(
+    "/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="회원 탈퇴",
+)
+async def delete_user(
+    user_id: Annotated[int, Path(description="삭제할 사용자 ID")],
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_admin)
+):
+    domain_req = DomainReqAdminDelUser(
+        user_id=user_id
+    )
+    await service_admin_delete_user(domain_req, db)
+    return


### PR DESCRIPTION
## 배경 (AS-IS)
<!-- 현재 코드의 문제점 또는 개선이 필요한 부분을 설명해주세요 -->
API 정의서에 따라 관리자용 회원 탈퇴 기능 구현이 필요함.

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->
라우트 단에서 유저가 관리자인지 확인 후, user_id에 해당하는 회원에 대해 delete_item 함수를 사용하여 논리 삭제를 실행.

## 체크리스트
- [ ] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [x] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [x] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
