### PR TITLE
Fix/회원 전체 대출 목록, 도서구매 목록 route 수정

### DIFF
--- a/src/domain/services/bookrequest_service.py
+++ b/src/domain/services/bookrequest_service.py
@@ -114,7 +114,11 @@ async def service_update_bookrequest(request_data: DomainReqPutBookRequest, db: 
     return response
 
 
-async def service_read_bookrequest_list(request_data: DomainReqGetBookRequest, db: Session) -> list[DomainResBookRequest]:
+async def service_read_bookrequest_list(
+        request_data: DomainReqGetBookRequest,
+        db: Session
+    ) -> list[DomainResBookRequest]:
+
     stmt = (
         select(RequestedBook)
         .where(and_(RequestedBook.user_id == request_data.user_id, RequestedBook.is_deleted == False))

--- a/src/domain/services/loan_service.py
+++ b/src/domain/services/loan_service.py
@@ -35,6 +35,8 @@ async def service_read_loans_by_user_id(user_id, db: Session):
             )
             for loan in loans
         ]
+    except HTTPException as e:
+        raise e from e
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/routes/bookrequest_route.py
+++ b/src/routes/bookrequest_route.py
@@ -4,18 +4,16 @@ from sqlalchemy.orm import Session
 from dependencies import get_current_active_user, get_db
 from domain.schemas.bookrequest_schemas import (
     DomainReqDelBookRequest,
-    DomainReqGetBookRequest,
     DomainReqPostBookRequest,
     DomainReqPutBookRequest,
 )
 from domain.services.bookrequest_service import (
     service_create_bookrequest,
     service_delete_bookrequest,
-    service_read_bookrequest_list,
     service_update_bookrequest,
 )
 from routes.request.bookrequest_request import RouteReqPostBookRequest, RouteReqPutBookRequest
-from routes.response.bookrequest_response import RouteResBookRequest, RouteResBookRequestList, RouteResPostBookRequest
+from routes.response.bookrequest_response import RouteResBookRequest, RouteResPostBookRequest
 
 router = APIRouter(
     prefix="/book-requests",
@@ -55,36 +53,6 @@ async def create_book_request(
         processing_status=result.processing_status
     )
 
-    return result
-
-
-@router.get(
-    "/my-requests",
-    summary="user의 도서 구매 요청 목록 조회",
-    response_model=RouteResBookRequestList,
-    status_code=status.HTTP_200_OK,
-)
-async def get_user_bookrequests(
-    db: Session = Depends(get_db), current_user=Depends(get_current_active_user)
-):
-    domain_req = DomainReqGetBookRequest(user_id=current_user.id)
-    domain_res = await service_read_bookrequest_list(domain_req, db)
-    converted_res = [
-        RouteResBookRequest(
-            user_id=item.user_id,
-            request_id=item.request_id,
-            book_title=item.book_title,
-            publication_year=item.publication_year,
-            request_link=item.request_link,
-            reason=item.reason,
-            processing_status=item.processing_status,
-            request_date=item.request_date,
-            reject_reason=item.reject_reason,
-        )
-        for item in domain_res
-    ]
-
-    result = RouteResBookRequestList(data=converted_res, count=len(converted_res))
     return result
 
 

--- a/src/routes/bookrequest_route.py
+++ b/src/routes/bookrequest_route.py
@@ -57,7 +57,7 @@ async def create_book_request(
 
 
 @router.put(
-    "/users/{request_id}",
+    "/{request_id}",
     summary="user의 도서 구매 요청 수정",
     response_model=RouteResBookRequest,
     status_code=status.HTTP_200_OK,

--- a/src/routes/user_route.py
+++ b/src/routes/user_route.py
@@ -2,11 +2,14 @@ from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm import Session
 
 from dependencies import get_current_active_user, get_db
+from domain.schemas.bookrequest_schemas import DomainReqGetBookRequest
+from domain.services.bookrequest_service import service_read_bookrequest_list
 from domain.services.loan_service import service_read_loans_by_user_id
 from domain.services.user_service import service_read_user, service_update_user
+from routes.request.user_request import RouteReqPutUser
+from routes.response.bookrequest_response import RouteResBookRequest, RouteResBookRequestList
 from routes.response.loan_response import RouteResGetLoanList
 from routes.response.user_response import RouteResGetUser, RouteResPutUser
-from routes.request.user_request import RouteReqPutUser
 
 router = APIRouter(
     prefix="/users",
@@ -14,9 +17,8 @@ router = APIRouter(
     dependencies=[Depends(get_current_active_user)]
 )
 
-
 @router.get(
-    "/{user_id}/loans",
+    "/my-loans",
     response_model=RouteResGetLoanList,
     status_code=status.HTTP_200_OK,
     summary="회원의 전체 대출 목록 조회",
@@ -55,6 +57,35 @@ async def get_user(
         instagram=result.instagram
     )
     return response
+
+@router.get(
+    "/my-requests",
+    summary="user의 도서 구매 요청 목록 조회",
+    response_model=RouteResBookRequestList,
+    status_code=status.HTTP_200_OK,
+)
+async def get_user_bookrequests(
+    db: Session = Depends(get_db), current_user=Depends(get_current_active_user)
+):
+    domain_req = DomainReqGetBookRequest(user_id=current_user.id)
+    domain_res = await service_read_bookrequest_list(domain_req, db)
+    converted_res = [
+        RouteResBookRequest(
+            user_id=item.user_id,
+            request_id=item.request_id,
+            book_title=item.book_title,
+            publication_year=item.publication_year,
+            request_link=item.request_link,
+            reason=item.reason,
+            processing_status=item.processing_status,
+            request_date=item.request_date,
+            reject_reason=item.reject_reason,
+        )
+        for item in domain_res
+    ]
+
+    result = RouteResBookRequestList(data=converted_res, count=len(converted_res))
+    return result
 
 @router.put(
     "/my-info",


### PR DESCRIPTION
## 배경 (AS-IS)
<!-- 현재 코드의 문제점 또는 개선이 필요한 부분을 설명해주세요 -->
- service_read_loans_by_user_id에서 404 에러가 500으로 raise 되는 문제
- 회원의 전체 대출 목록 조회 : 사용하지 않는 user_id를 route path 적용, 
- 회원의 전체 도서구매목록 조회 API만 /book-requests 하위 route로 할당됨. 일관되지 않은 route 문제 

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->
- service_read_loans_by_user_id에 HTTPException이 바로 raise 되도록 코드 추가
- users/{user_id}/loan -> users/my-loans 로 route 변경
- book-requests/my-requests -> user/my-requests로 route 변경
- 도서 구매 요청 수정 API(User) route /book-requests/{request_id}로 수정


## 체크리스트
- [ ] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [ ] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
