### PR TITLE
fix: 일반회원 공지사항 조회 get_current_active_user 제거

### DIFF
--- a/src/routes/notice_route.py
+++ b/src/routes/notice_route.py
@@ -1,14 +1,13 @@
 from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.orm import Session
 
-from dependencies import get_current_active_user, get_db
+from dependencies import get_db
 from domain.services.notice_service import service_read_notice, service_read_notices
 from routes.response.notice_response import RouteResGetNotice, RouteResGetNoticeList
 
 router=APIRouter(
     prefix="/notice",
-    tags=["notice"],
-    dependencies=[Depends(get_current_active_user)]
+    tags=["notice"]
 )
 
 @router.get(
@@ -21,8 +20,7 @@ router=APIRouter(
 async def get_all_notices(
     page: int = Query(1, ge=1),
     limit: int = Query(7, le=50),
-    db: Session=Depends(get_db),
-    current_user=Depends(get_current_active_user)
+    db: Session=Depends(get_db)
 ):
     domain_res, total = await service_read_notices(page, limit, db)
     response = RouteResGetNoticeList(
@@ -43,8 +41,7 @@ async def get_all_notices(
 
 async def get_notice(
     notice_id: int,
-    db: Session=Depends(get_db),
-    current_user=Depends(get_current_active_user)
+    db: Session=Depends(get_db)
 ):
     domain_res = await service_read_notice(notice_id, db)
     response = RouteResGetNotice(


### PR DESCRIPTION
## 배경 (AS-IS)
일반회원 공지사항 전체 조회, id 조회 API get_current_active_user 및 dependency 제거

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->

## 체크리스트
- [ ] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [ ] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
