### PR TITLE
fix: add 'loanable' in domain/route dto

### DIFF
--- a/src/domain/schemas/book_schemas.py
+++ b/src/domain/schemas/book_schemas.py
@@ -11,6 +11,7 @@ class DomainReqGetBook(BaseModel):
 class DomainResGetBook(BaseModel):
     book_id: int = Field(title="book_id", description="책 ID", example=1, gt=0)
     book_title: str = Field(title="book_title", description="책 제목", example="FastAPI Tutorial")
+    loanable: bool = Field(title="loanable", description="대출 가능 여부", default=True)
     code: str = Field(title="code", description="책 코드", example="A3")
     category_name: str = Field(title="category_name", description="카테고리 이름", example="웹")
     subtitle: str | None = Field(title="subtitle", description="부제목", example="for beginner")

--- a/src/domain/services/book_service.py
+++ b/src/domain/services/book_service.py
@@ -102,9 +102,12 @@ async def service_read_book(request_data: DomainReqGetBook, db: Session):
     if not book:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Requested book not found")
 
+    loanable = False if book.loans and book.loans[-1].return_status == False else True
+
     response = DomainResGetBook(
         book_id=book.id,
         book_title=book.book_title,
+        loanable=loanable,
         code=book.code,
         category_name=book.category_name,
         subtitle=book.subtitle,

--- a/src/routes/books_route.py
+++ b/src/routes/books_route.py
@@ -29,6 +29,7 @@ async def get_book_by_book_id(
     result = RouteResGetBook(
         book_id=domain_res.book_id,
         book_title=domain_res.book_title,
+        loanable=domain_res.loanable,
         code=domain_res.code,
         category_name=domain_res.category_name,
         subtitle=domain_res.subtitle,

--- a/src/routes/response/book_response.py
+++ b/src/routes/response/book_response.py
@@ -11,6 +11,7 @@ class RouteResGetBookList(BaseModel):
 class RouteResGetBook(BaseModel):
     book_id: int = Field(title="book_id", description="책 ID", example=1, gt=0)
     book_title: str = Field(title="book_title", description="책 제목", example="FastAPI Tutorial")
+    loanable: bool = Field(title="loanable", description="대출 가능 여부", default=True)
     code: str = Field(title="code", description="책 코드", example="A3")
     category_name: str = Field(title="category_name", description="카테고리 이름", example="웹")
     subtitle: str | None = Field(title="subtitle", description="부제목", example="for beginner")


### PR DESCRIPTION
## 배경 (AS-IS)
도서 상세 조회 시 loanable(대출 가능 여부)가 스키마에 없었음

## 변경 사항 (TO-BE)
해당 도서의 loans가 존재하고, 가장 최근 loan의 return status가 False일 때만 False인 loanable 추가

## 체크리스트
- [ ] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [ ] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
