### PR TITLE
Fix : 일반 도서 검색 및 도서 id 조회 - loanable 값 설정 로직 디버깅

### DIFF
--- a/src/domain/schemas/book_schemas.py
+++ b/src/domain/schemas/book_schemas.py
@@ -36,7 +36,7 @@ class DomainResGetBookList(BaseModel):
     book_status: bool = Field(title="book_stauts", description="책 상태", example=True)
     created_at: datetime = Field(title="create_at", description="생성일시", example=datetime.now())
     updated_at: datetime = Field(title="update_at", description="수정일시", example=datetime.now())
-    is_loanable: bool | None = Field(title="loan_status", description="대출 상태", example=False)
+    loanable: bool | None = Field(title="loan_status", description="대출 상태", example=False)
 
 
 class DomainResGetBookListWithTotal(BaseModel):

--- a/src/repositories/models.py
+++ b/src/repositories/models.py
@@ -125,8 +125,7 @@ class Book(Base):
 
     # Relationships
     book_reviews = relationship("BookReview", back_populates="book")
-    loans = relationship("Loan", back_populates="book")
-
+    loans = relationship("Loan", back_populates="book", order_by="Loan.updated_at.desc()")  # order_by 적용
 
 class Notice(Base):
     __tablename__ = "notice"


### PR DESCRIPTION
## 배경 (AS-IS)
<!-- 현재 코드의 문제점 또는 개선이 필요한 부분을 설명해주세요 -->
- #123 loanable 값이 올바르지 않으며(SQL 문제), is_loanable의 값으로 검사되지 않음.
- #122 loanable 값이 올바르지 않음(loans를 created_at을 기준으로 정렬)

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->
- 검색 쿼리 = `is_loanable`, response = `loanable`
- Book.loans 를 updated_at.desc()로 정렬 (`models.py` )
- Book.loans.return_status 조회 시 해당 loan.is_deleted = False 조건 추가
- loanable 값 할당 로직 수정

## 체크리스트
- [ ] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [ ] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
