### PR TITLE
Hotfix: Add overdue days field to `/admin/loans/` (전체 대출 목록 조회)

### DIFF
--- a/src/domain/schemas/loan_schemas.py
+++ b/src/domain/schemas/loan_schemas.py
@@ -55,6 +55,7 @@ class DomainResAdminGetLoan(BaseModel):
     category_name: str = Field(title="category_name", description="카테고리명", example="웹")
     loan_date: date = Field(title="loan_date", description="대출 날짜", example=datetime.today().date())
     due_date: date = Field(title="due_date", description="반납 기한", example=(datetime.today() + timedelta(days=14)).date())
+    overdue_days: int = Field(title="overdue_days", description="연체 일자", example=1)
     extend_status: bool = Field(title="extend_status", description="연장 상태", example=True)
     return_status: bool = Field(title="return_status", description="반납 상태", example=False)
     return_date: date | None = Field(title="return_date", description="반납 날짜", example=None)

--- a/src/domain/services/admin/loan_service.py
+++ b/src/domain/services/admin/loan_service.py
@@ -181,6 +181,7 @@ async def service_admin_read_loans(db: Session) -> list[DomainResAdminGetLoan]:
                     category_name=loan.book.category_name,
                     loan_date=loan.loan_date,
                     due_date=loan.due_date,
+                    overdue_days=loan.overdue_days,
                     extend_status=loan.extend_status,
                     return_status=loan.return_status,
                     return_date=loan.return_date,


### PR DESCRIPTION
## 배경 (AS-IS)
<!-- 현재 코드의 문제점 또는 개선이 필요한 부분을 설명해주세요 -->
GET /admin/loans/ 에서 overdue_days 필드가 없어서 연체 확인이 힘듦

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->
DomainResAdminGetLoan 스키마에 overdue_days 필드 추가

## 체크리스트
- [x] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [x] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
