### PR TITLE
Hotfix : 도서 검색 loanable None 값 처리 및 도서 조회 Response 스키마 수정

### DIFF
--- a/src/domain/schemas/book_schemas.py
+++ b/src/domain/schemas/book_schemas.py
@@ -28,7 +28,7 @@ class DomainResGetBook(BaseModel):
     updated_at: datetime = Field(title="update_at", description="수정일시", example=datetime.now())
 
 
-class DomainResGetBookList(BaseModel):
+class DomainResGetBookItem(BaseModel):
     book_id: int = Field(title="book_id", description="책 ID", example=1, gt=0)
     book_title: str = Field(title="book_title", description="책 제목", example="FastAPI Tutorial")
     category_name: str = Field(title="category_name", description="카테고리 이름", example="웹")
@@ -39,8 +39,9 @@ class DomainResGetBookList(BaseModel):
     loanable: bool | None = Field(title="loan_status", description="대출 상태", example=False)
 
 
-class DomainResGetBookListWithTotal(BaseModel):
-    data: list[DomainResGetBookList]
+class DomainResGetBookList(BaseModel):
+    data: list[DomainResGetBookItem]
+    count : int = Field(description="data 배열의 요소 개수")
     total: int = Field(description="Book 객체의 총 요소 개수")
 
 

--- a/src/domain/services/book_service.py
+++ b/src/domain/services/book_service.py
@@ -74,7 +74,7 @@ async def service_search_books(
                 stmt = stmt.where(or_(latest_loan_subq == True, latest_loan_subq.is_(None)))
 
 
-    print(stmt) # 디버깅용
+    # print(stmt) # 디버깅용
     try:
         books = (
             db.execute(

--- a/src/domain/services/book_service.py
+++ b/src/domain/services/book_service.py
@@ -244,7 +244,7 @@ async def service_read_books(page: int, limit: int, db: Session):
         loanable = True if loan_status is None else loan_status
 
         result.append(
-            DomainResGetBookList(
+            DomainResGetBookItem(
                 book_id=book_id,
                 book_title=book_title,
                 category_name=category_name,

--- a/src/routes/books_route.py
+++ b/src/routes/books_route.py
@@ -43,7 +43,7 @@ async def search_books(
     )
     result = RouteResGetBookList(
         data=domain_res.data,
-        count=domain_res.count,
+        count=len(domain_res.data),
         total=domain_res.total
     )
 
@@ -103,11 +103,7 @@ async def get_books(
     domain_res = await service_read_books(page, limit, db)
     result = RouteResGetBookList(
         data=domain_res.data,
-<<<<<<< HEAD
-        count=domain_res.count,
-=======
         count=len(domain_res.data),
->>>>>>> 9942b3de2400ca10541f828cf7fb787437736a6c
         total=domain_res.total
     )
 

--- a/src/routes/books_route.py
+++ b/src/routes/books_route.py
@@ -43,7 +43,7 @@ async def search_books(
     )
     result = RouteResGetBookList(
         data=domain_res.data,
-        count=len(domain_res.data),
+        count=domain_res.count,
         total=domain_res.total
     )
 
@@ -102,8 +102,9 @@ async def get_books(
 ):
     domain_res = await service_read_books(page, limit, db)
     result = RouteResGetBookList(
-        data=domain_res,
-        count=len(domain_res)
+        data=domain_res.data,
+        count=domain_res.count,
+        total=domain_res.total
     )
 
     return result

--- a/src/routes/response/book_response.py
+++ b/src/routes/response/book_response.py
@@ -1,12 +1,12 @@
 from pydantic import BaseModel, Field
 
-from domain.schemas.book_schemas import DomainResGetBookList
+from domain.schemas.book_schemas import DomainResGetBookItem
 
 
 class RouteResGetBookList(BaseModel):
-    data: list[DomainResGetBookList]
+    data: list[DomainResGetBookItem]
     count: int = Field(description="data 배열의 요소 개수")
-    total: int = Field(description="data 배열의 총 요소 개수")
+    total: int = Field(description="객체의 총 요소 개수")
 
 
 class RouteResGetBook(BaseModel):


### PR DESCRIPTION
## 배경 (AS-IS)
<!-- 현재 코드의 문제점 또는 개선이 필요한 부분을 설명해주세요 -->
- loanable 값이 None 경우 발생 (해당 도서의 대출 정보가 없을 때)
- 전체 도서 정보 조회시 loanable 누락 오류
- Response 스키마의 복잡한 이름, 
- count를 route에서 처리하는 문제

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->
**- loanable 이 None인 경우 True로 할당**
- 전체 도서 정보 조회 response에` loanable=True`, `total=144 `임시 할당
- count 값을 service 함수 내에서 할당
-  `DomainResGetBookList` -> `DomainResGetBookItem`, 
-  `DomainResGetBookListWithTotal` -> `DomainResGetBookList`로 스키마 이름 수정, count 추가

## 체크리스트
- [x] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [x] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
