### PR TITLE
Fix/update admin return loan service logic for return status handling

### DIFF
--- a/src/domain/schemas/loan_schemas.py
+++ b/src/domain/schemas/loan_schemas.py
@@ -14,7 +14,7 @@ class DomainResGetLoan(BaseModel):
     due_date: date = Field(title="due_date", description="반납 기한", example=(datetime.today() + timedelta(days=14)).date())
     extend_status: bool = Field(title="extend_status", description="연장 상태", example=True)
     overdue_days: int = Field(title="overdue_days", description="연체 일자", example=1)
-    return_status: bool = Field(title="return_status", description="반납 상태", example=False)
+    return_status: bool = Field(title="return_status", description="반납 상태", example=False) # 0: 대출중, 1: 반납완료 -> 0: 대출 불가능, 1: 대출 가능
     return_date: date | None = Field(title="return_date", description="반납 날짜", example=None)
     book_title: str = Field(title="book_title", description="책 제목", example="FastAPI Tutorial")
     code: str = Field(title="code", description="책 코드", example="A3")

--- a/src/domain/services/admin/loan_service.py
+++ b/src/domain/services/admin/loan_service.py
@@ -17,12 +17,15 @@ async def service_admin_toggle_loan_return(
     loan = get_item(Loan, loan_id, db)
 
     try:
-        if loan.return_status: # 반납 상태가 True이면 False로 변경
+        if loan.return_status: # return_stauts가 True이면 False로 변경
             loan.return_status = False
             loan.return_date = None
-        else: # 반납 상태가 False이면 True로 변경
+            # loan.overdue_days = None # 굳이 db에 저장할 필요가 없을 것 같아서 주석 처리
+        else: # return_status가 False이면 True로 변경
             loan.return_status = True
             loan.return_date = datetime.now().date()
+            days_diff = (loan.return_date - loan.due_date).days
+            loan.overdue_days = max(days_diff, 0)  # Negative values become 0
 
         db.flush()
     except HTTPException as e:
@@ -50,6 +53,9 @@ async def service_admin_toggle_loan_return(
             overdue_days=loan.overdue_days,
             return_status=loan.return_status,
             return_date=loan.return_date,
+            book_title=loan.book.book_title,
+            code=loan.book.code,
+            version=loan.book.version,
         )
 
     return result


### PR DESCRIPTION
## 배경 (AS-IS)
<!-- 현재 코드의 문제점 또는 개선이 필요한 부분을 설명해주세요 -->
대출을 반납 처리할 때 DB에 overdue_days 계산을 하고 있지 않음
정상적으로 로직은 처리가 되었는데, 500 internal error가 발생하고 있었음

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->
overdue_days를 계산하고 0보다 클 경우, DB에 반영하도록 함
반환 필드에 book_title, code, version이 빠져있어 추가함

## 체크리스트
- [ ] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [ ] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
