### PR TITLE
Feat/calculate overdue days

### DIFF
--- a/src/domain/services/admin/loan_service.py
+++ b/src/domain/services/admin/loan_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from domain.schemas.loan_schemas import DomainResAdminGetLoan, DomainResGetLoan
 from repositories.models import Loan
-from utils.crud_utils import get_item
+from utils.crud_utils import calculate_overdue_days, get_item
 
 
 async def service_admin_toggle_loan_return(
@@ -24,8 +24,7 @@ async def service_admin_toggle_loan_return(
         else: # return_status가 False이면 True로 변경
             loan.return_status = True
             loan.return_date = datetime.now().date()
-            days_diff = (loan.return_date - loan.due_date).days
-            loan.overdue_days = max(days_diff, 0)  # Negative values become 0
+            loan.overdue_days = calculate_overdue_days(loan.due_date)
 
         db.flush()
     except HTTPException as e:
@@ -50,7 +49,7 @@ async def service_admin_toggle_loan_return(
             loan_date=loan.loan_date,
             due_date=loan.due_date,
             extend_status=loan.extend_status,
-            overdue_days=loan.overdue_days,
+            overdue_days=calculate_overdue_days(loan.due_date),
             return_status=loan.return_status,
             return_date=loan.return_date,
             book_title=loan.book.book_title,
@@ -187,7 +186,7 @@ async def service_admin_read_loans(db: Session) -> list[DomainResAdminGetLoan]:
                     category_name=loan.book.category_name,
                     loan_date=loan.loan_date,
                     due_date=loan.due_date,
-                    overdue_days=loan.overdue_days,
+                    overdue_days=calculate_overdue_days(loan.due_date),
                     extend_status=loan.extend_status,
                     return_status=loan.return_status,
                     return_date=loan.return_date,

--- a/src/domain/services/loan_service.py
+++ b/src/domain/services/loan_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from domain.schemas.loan_schemas import DomainReqPostLoan, DomainReqPutLoan, DomainResGetLoan
 from repositories.models import Book, Loan
-from utils.crud_utils import get_item
+from utils.crud_utils import calculate_overdue_days, get_item
 
 
 async def service_read_loans_by_user_id(
@@ -44,7 +44,7 @@ async def service_read_loans_by_user_id(
                         loan_date=loan.loan_date,
                         due_date=loan.due_date,
                         extend_status=loan.extend_status,
-                        overdue_days=loan.overdue_days,
+                        overdue_days=calculate_overdue_days(loan.due_date),
                         return_status=loan.return_status,
                         return_date=loan.return_date,
                         book_title=loan.book.book_title,
@@ -104,7 +104,7 @@ async def service_extend_loan(request: DomainReqPutLoan, db: Session):
             loan_date=loan.loan_date,
             due_date=loan.due_date,
             extend_status=loan.extend_status,
-            overdue_days=loan.overdue_days,
+            overdue_days=calculate_overdue_days(loan.due_date),
             return_status=loan.return_status,
             return_date=loan.return_date,
         )
@@ -156,7 +156,7 @@ async def service_create_loan(request: DomainReqPostLoan, db: Session):
             loan_date=loan.loan_date,
             due_date=loan.due_date,
             extend_status=loan.extend_status,
-            overdue_days=loan.overdue_days,
+            overdue_days=calculate_overdue_days(loan.due_date),
             return_status=loan.return_status,
             return_date=loan.return_date,
         )

--- a/src/utils/crud_utils.py
+++ b/src/utils/crud_utils.py
@@ -1,4 +1,6 @@
 
+from datetime import date
+
 from fastapi import HTTPException, status
 from sqlalchemy import and_, delete, select, update
 from sqlalchemy.exc import NoResultFound
@@ -141,3 +143,9 @@ def delete_item_dba(model, index: int, db: Session):
 #     result = db.scalars(stmt).all()
 
 #     return result
+
+def calculate_overdue_days(due_date: date) -> int:
+    today = date.today()
+    overdue = (today - due_date).days
+
+    return max(overdue, 0)


### PR DESCRIPTION
## 배경 (AS-IS)
<!-- 현재 코드의 문제점 또는 개선이 필요한 부분을 설명해주세요 -->
overdue_days(연체일)가 현재 시간에 맞지 않게 DB에 있는 값을 그대로 반환하는 문제가 있음

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->
crud_utils에 인수를 `date`로 반환 값을 `int`로 하는 calculate_overdue_days 함수를 만들어 중복을 줄이고 코드의 명확성을 높임.
date.today()와 due_date의 차이 만큼을 계산하고 0보다 클 경우 이 차이를 반환하고 0보다 작을 경우 0을 반환하도록 함

## 체크리스트
- [ ] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [ ] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
