### PR TITLE
Feat/add is admin in login response

### DIFF
--- a/src/domain/schemas/auth_schemas.py
+++ b/src/domain/schemas/auth_schemas.py
@@ -8,6 +8,7 @@ class UserInfo(BaseModel):
     user_name: str
     is_active: bool
     email: EmailStr = Field(..., example="test@test.com")
+    is_admin: bool
 
 
 class FirebaseLoginRequest(BaseModel):

--- a/src/domain/services/admin/loan_service.py
+++ b/src/domain/services/admin/loan_service.py
@@ -8,7 +8,8 @@ from sqlalchemy.orm import Session, selectinload
 
 from domain.schemas.loan_schemas import DomainResAdminGetLoan, DomainResAdminGetLoanList, DomainResGetLoan
 from repositories.models import Loan
-from utils.crud_utils import calculate_overdue_days, get_item
+from utils.crud_utils import get_item
+from utils.shared_utils import calculate_overdue_days
 
 
 async def service_admin_toggle_loan_return(

--- a/src/domain/services/auth_service.py
+++ b/src/domain/services/auth_service.py
@@ -8,6 +8,7 @@ from domain.schemas.auth_schemas import LoginRequest, LoginResponse, RegisterReq
 from domain.services.token_service import create_user_tokens, verify_jwt
 from externals.firebase import sign_in_with_email_and_password
 from repositories.models import User
+from utils.shared_utils import get_admin_status
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 async def service_register(request: RegisterRequest, db: Session):
@@ -41,7 +42,8 @@ async def service_register(request: RegisterRequest, db: Session):
             id=user.id,
             user_name=user.user_name,
             email=user.email,
-            is_active=user.is_active
+            is_active=user.is_active,
+            is_admin=get_admin_status(user.id, db)
         )
     ).model_dump()
     response = JSONResponse(content=user_info, status_code=status.HTTP_201_CREATED)
@@ -85,7 +87,8 @@ async def service_login_sso(request:LoginRequest, db: Session):
             id=user.id,
             user_name=user.user_name,
             email=user.email,
-            is_active=user.is_active
+            is_active=user.is_active,
+            is_admin=get_admin_status(user.id, db)
         )
     ).model_dump()
     response = JSONResponse(content=login_response, status_code=status.HTTP_200_OK)
@@ -96,8 +99,9 @@ async def service_login_sso(request:LoginRequest, db: Session):
 
 
 async def service_login(
-        request: LoginRequest,
-        db: Session):
+    request: LoginRequest,
+    db: Session
+):
     # Authenticate user
     # Check if user information exists in the DB
     user = db.query(User).filter(User.email == request.email, User.is_deleted==False).first()
@@ -116,7 +120,8 @@ async def service_login(
             id=user.id,
             user_name=user.user_name,
             email=user.email,
-            is_active=user.is_active
+            is_active=user.is_active,
+            is_admin=get_admin_status(user.id, db)
         )
     ).model_dump()
     response = JSONResponse(content=login_response, status_code=status.HTTP_200_OK, headers={

--- a/src/domain/services/loan_service.py
+++ b/src/domain/services/loan_service.py
@@ -6,7 +6,8 @@ from sqlalchemy.orm import Session
 
 from domain.schemas.loan_schemas import DomainReqPostLoan, DomainReqPutLoan, DomainResGetLoan
 from repositories.models import Book, Loan
-from utils.crud_utils import calculate_overdue_days, get_item
+from utils.crud_utils import get_item
+from utils.shared_utils import calculate_overdue_days
 
 
 async def service_read_loans_by_user_id(

--- a/src/utils/crud_utils.py
+++ b/src/utils/crud_utils.py
@@ -1,6 +1,3 @@
-
-from datetime import date
-
 from fastapi import HTTPException, status
 from sqlalchemy import and_, delete, select, update
 from sqlalchemy.exc import NoResultFound
@@ -143,9 +140,3 @@ def delete_item_dba(model, index: int, db: Session):
 #     result = db.scalars(stmt).all()
 
 #     return result
-
-def calculate_overdue_days(due_date: date) -> int:
-    today = date.today()
-    overdue = (today - due_date).days
-
-    return max(overdue, 0)

--- a/src/utils/shared_utils.py
+++ b/src/utils/shared_utils.py
@@ -69,3 +69,9 @@ def get_admin_status(user_id: int, db: Session) -> bool:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Unexpected error while checking admin status: {str(e)}"
         ) from e
+
+def calculate_overdue_days(due_date: date) -> int:
+    today = date.today()
+    overdue = (today - due_date).days
+
+    return max(overdue, 0)

--- a/src/utils/shared_utils.py
+++ b/src/utils/shared_utils.py
@@ -70,6 +70,7 @@ def get_admin_status(user_id: int, db: Session) -> bool:
             detail=f"Unexpected error while checking admin status: {str(e)}"
         ) from e
 
+
 def calculate_overdue_days(due_date: date) -> int:
     today = date.today()
     overdue = (today - due_date).days

--- a/src/utils/shared_utils.py
+++ b/src/utils/shared_utils.py
@@ -1,0 +1,71 @@
+from datetime import date
+
+from fastapi import HTTPException, status
+from sqlalchemy import and_, select
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.exc import NoResultFound
+
+
+def get_admin_status(user_id: int, db: Session) -> bool:
+    """
+    Check if the user with the given user_id is an admin and return their admin status.
+
+    Args:
+        user_id (int): The ID of the user to check
+        db (Session): SQLAlchemy database session
+
+    Returns:
+        bool: True if the user is an active admin, False otherwise
+
+    Raises:
+        HTTPException:
+            - 404: User not found
+            - 500: Unexpected database error
+    """
+    from src.repositories.models import User
+
+    if not isinstance(user_id, int) or user_id <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid user ID"
+        )
+
+    try:
+        stmt = select(User).where(and_(User.id == user_id, User.is_deleted == False))
+        user = db.execute(stmt).scalar_one_or_none()
+
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User not found"
+            )
+
+        if not user.admin:
+            return False
+
+        # Get the most recent admin record
+        latest_admin = max(user.admin, key=lambda admin: admin.updated_at, default=None)
+        if latest_admin is None:
+            return False
+
+        # Check admin status conditions
+        is_active_admin = (
+            not latest_admin.is_deleted and
+            latest_admin.admin_status and
+            latest_admin.expiration_date >= date.today()
+        )
+
+        return is_active_admin
+
+    except NoResultFound:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found"
+        ) from NoResultFound
+    except HTTPException as e:
+        raise e
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error while checking admin status: {str(e)}"
+        ) from e

--- a/src/utils/shared_utils.py
+++ b/src/utils/shared_utils.py
@@ -22,7 +22,7 @@ def get_admin_status(user_id: int, db: Session) -> bool:
             - 404: User not found
             - 500: Unexpected database error
     """
-    from src.repositories.models import User
+    from repositories.models import User
 
     if not isinstance(user_id, int) or user_id <= 0:
         raise HTTPException(
@@ -44,7 +44,7 @@ def get_admin_status(user_id: int, db: Session) -> bool:
             return False
 
         # Get the most recent admin record
-        latest_admin = max(user.admin, key=lambda admin: admin.updated_at, default=None)
+        latest_admin = max(user.admin, key=lambda admin: admin.created_at, default=None)
         if latest_admin is None:
             return False
 


### PR DESCRIPTION
## 배경 (AS-IS)
<!-- 현재 코드의 문제점 또는 개선이 필요한 부분을 설명해주세요 -->
login response에 is_admin 필드가 필요함.

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->
utils/shared_utils.py에 `get_admin_status` 함수를 만들어 관리.
`UserInfo` 스키마에 is_admin 필드 추가
`service_register`, `service_login`, `service_login_sso` 함수에 is_admin=get_admin_status(user_id, db) 추가

crud_utils.py에 있던 `calculate_overdue_days`를 shared_utils.py로 이동

## 체크리스트
- [ ] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [ ] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
