### PR TITLE
feat: remove version field from loan schemas and related services

### DIFF
--- a/src/domain/schemas/loan_schemas.py
+++ b/src/domain/schemas/loan_schemas.py
@@ -18,7 +18,6 @@ class DomainResGetLoan(BaseModel):
     return_date: date | None = Field(title="return_date", description="반납 날짜", example=None)
     book_title: str = Field(title="book_title", description="책 제목", example="FastAPI Tutorial")
     code: str = Field(title="code", description="책 코드", example="A3")
-    version: str | None = Field(title="version", description="판본", example="10e")
 
 
 class DomainReqPutLoan(BaseModel):

--- a/src/domain/services/admin/loan_service.py
+++ b/src/domain/services/admin/loan_service.py
@@ -55,7 +55,6 @@ async def service_admin_toggle_loan_return(
             return_date=loan.return_date,
             book_title=loan.book.book_title,
             code=loan.book.code,
-            version=loan.book.version,
         )
 
     return result

--- a/src/domain/services/loan_service.py
+++ b/src/domain/services/loan_service.py
@@ -49,7 +49,6 @@ async def service_read_loans_by_user_id(
                         return_date=loan.return_date,
                         book_title=loan.book.book_title,
                         code=loan.book.code,
-                        version=loan.book.version,
                     )
                 )
 
@@ -107,6 +106,8 @@ async def service_extend_loan(request: DomainReqPutLoan, db: Session):
             overdue_days=calculate_overdue_days(loan.due_date),
             return_status=loan.return_status,
             return_date=loan.return_date,
+            book_title=loan.book.book_title,
+            code=loan.book.code,
         )
 
     return result
@@ -159,5 +160,7 @@ async def service_create_loan(request: DomainReqPostLoan, db: Session):
             overdue_days=calculate_overdue_days(loan.due_date),
             return_status=loan.return_status,
             return_date=loan.return_date,
+            book_title=loan.book.book_title,
+            code=loan.book.code,
         )
         return result


### PR DESCRIPTION
## 배경 (AS-IS)
<!-- 현재 코드의 문제점 또는 개선이 필요한 부분을 설명해주세요 -->
`DomainResGetLoan` 스키마의 version 필드가 필요하지 않음. 

## 변경 사항 (TO-BE)
<!-- 문제를 어떻게 해결했는지, 무엇을 개선했는지 설명해주세요 -->
version 필드 삭제.
`DomainResGetLoan`를 사용하는 서비스 함수들에서 알맞은 필드를 제공하도록 수정.

## 체크리스트
- [ ] 긴급 PR: callout 라벨 추가 및 카카오톡에 공유
- [ ] 담당 영역 라벨 추가 완료
- [ ] 테스트 코드 작성/수정 완료
- [ ] 관련 문서 업데이트 완료
- [ ] Breaking Change 있는 경우 관련 팀 공유 완료
